### PR TITLE
Replace `gemini-pro-vision` with `gemini-1.5-pro-latest`

### DIFF
--- a/mllm/router.py
+++ b/mllm/router.py
@@ -41,7 +41,7 @@ class Router:
         "gpt-4o": "OPENAI_API_KEY",
         "gpt-4-turbo": "OPENAI_API_KEY",
         "anthropic/claude-3-opus-20240229": "ANTHROPIC_API_KEY",
-        "gemini/gemini-pro-vision": "GEMINI_API_KEY",
+        "gemini/gemini-1.5-pro-latest": "GEMINI_API_KEY",
     }
 
     def __init__(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mllm"
-version = "0.1.32"
+version = "0.1.33"
 description = "Multimodal Large Language Models"
 authors = ["Patrick Barker <patrickbarkerco@gmail.com>"]
 license = "Apache 2.0"


### PR DESCRIPTION
`gemini-pro-vision` has been deprecated and replaced with `gemini-1.5-pro-latest`

For more info see: https://ai.google.dev/gemini-api/docs/models/gemini#gemini-1.0-pro-vision

Tests passed:

![image](https://github.com/agentsea/mllm/assets/9259160/dea34da0-f185-49a0-9099-f708315a9f77)
